### PR TITLE
don't use Uri.parse, it fails on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,7 +163,7 @@ export function activate(context: ExtensionContext) {
     'codeReview.openSelection',
     (fileSection: ReviewFileExportSection, csvRef?: CsvEntry) => {
       const filePath = path.join(workspaceRoot, fileSection.group);
-      workspace.openTextDocument(Uri.parse(filePath)).then(
+      workspace.openTextDocument(filePath).then(
         (doc) => {
           window.showTextDocument(doc, ViewColumn.One).then((textEditor) => {
             webview.panel?.dispose(); // dispose previous ones


### PR DESCRIPTION
Opening the review-comment fails in Windows. I suggest use the 
```
openTextDocument(fileName: string): Thenable<TextDocument>
```
overload instead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information