### PR TITLE
use "> -1" instead

### DIFF
--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -60,7 +60,7 @@ export class ReviewCommentService {
     const oldFileContent = fs.readFileSync(this.reviewFile, 'utf8'); // get old content
     const rows = oldFileContent.split(EOL);
     const updateRowIndex = rows.findIndex((row) => row.includes(comment.filename) && row.includes(comment.lines));
-    if (updateRowIndex >= -1) {
+    if (updateRowIndex > -1) {
       rows[updateRowIndex] = this.buildCsvString(comment);
     } else {
       window.showErrorMessage(
@@ -76,7 +76,7 @@ export class ReviewCommentService {
     const oldFileContent = fs.readFileSync(this.reviewFile, 'utf8'); // get old content
     const rows = oldFileContent.split(EOL);
     const updateRowIndex = rows.findIndex((row) => row.includes(entry.label) && row.includes(entry.text));
-    if (updateRowIndex >= -1) {
+    if (updateRowIndex > -1) {
       rows.splice(updateRowIndex, 1);
     } else {
       window.showErrorMessage(`Update failed. Cannot delete comment '${entry.label}' in '${this.reviewFile}'.`);


### PR DESCRIPTION
leads to incorrect behavior when the correct comment isn't found.

BTW it might prove wiser to use a dedicated CSV reader & writer for those tasks. See #60 for more details

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Removes incorrect lines, because -1 is considered as successful "fileIndex" results

## What is the new behavior?

-1 is considered as an error, the error indicator will appear when the correct row is not found

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information