### PR TITLE
fix(csv): escape/unescape end-of-line characters to avoid CSV store corruption

### DIFF
--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -8,6 +8,7 @@ import {
   removeLeadingAndTrailingSlash,
   removeTrailingSlash,
   escapeDoubleQuotesForCsv,
+  escapeEndOfLineForCsv,
   startLineNumberFromStringDefinition,
   endLineNumberFromStringDefinition,
 } from './utils/workspace-util';
@@ -86,7 +87,7 @@ export class ReviewCommentService {
 
   private buildCsvString(comment: CsvEntry): string {
     // escape double quotes
-    const commentExcaped = escapeDoubleQuotesForCsv(comment.comment);
+    const commentExcaped = escapeEndOfLineForCsv(escapeDoubleQuotesForCsv(comment.comment));
     const titleExcaped = comment.title ? escapeDoubleQuotesForCsv(comment.title) : '';
     const priority = comment.priority || 0;
     const additional = comment.additional ? escapeDoubleQuotesForCsv(comment.additional) : '';

--- a/src/test/suite/workspace-util.test.ts
+++ b/src/test/suite/workspace-util.test.ts
@@ -19,6 +19,8 @@ import {
   sortLineSelections,
   sortCsvEntryForLines,
   escapeDoubleQuotesForCsv,
+  escapeEndOfLineForCsv,
+  unescapeEndOfLineFromCsv,
   rangeFromStringDefinition,
 } from '../../utils/workspace-util';
 import { CsvEntry } from '../../interfaces';
@@ -132,6 +134,18 @@ suite('Workspace Utils', () => {
   suite('escapeDoubleQuotesForCsv', () => {
     test('should escape a double quote sign as expected for CSV files (with another ")', () => {
       assert.strictEqual(escapeDoubleQuotesForCsv('aa"bb'), 'aa""bb');
+    });
+  });
+
+  suite('escapeEndOfLineForCsv', () => {
+    test('should escape an end-of-line character as expected for CSV files (with a double anti-slash)', () => {
+      assert.strictEqual(escapeEndOfLineForCsv('aa\nbb'), 'aa\\nbb');
+    });
+  });
+
+  suite('unescapeEndOfLineFromCsv', () => {
+    test('should unescape an end-of-line marker as expected for CSV files (with a true eol)', () => {
+      assert.strictEqual(unescapeEndOfLineFromCsv('aa\\nbb'), 'aa\nbb');
     });
   });
 

--- a/src/utils/workspace-util.ts
+++ b/src/utils/workspace-util.ts
@@ -83,6 +83,22 @@ export const escapeDoubleQuotesForCsv = (input: string): string => {
 };
 
 /**
+ * End-of-line must be escaped in CSV files to prevent row discontinuity
+ * @param input the string that should be escaped
+ */
+export const escapeEndOfLineForCsv = (input: string): string => {
+  return input.replace(/\n/g, '\\n');
+};
+
+/**
+ * Restore escaped end-of-line for manipulation
+ * @param input the string that should be unescaped
+ */
+export const unescapeEndOfLineFromCsv = (input: string): string => {
+  return input.replace(/\\n/g, '\n');
+};
+
+/**
  * Retrieve the first start line definition from the lines string representation for CSV files
  * @param input the input string
  */

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import { ReviewCommentService } from './review-comment';
 import { CsvEntry } from './interfaces';
 import { CommentListEntry } from './comment-list-entry';
+import { unescapeEndOfLineFromCsv } from './utils/workspace-util';
 
 export class WebViewComponent {
   private categories: string[] = [];
@@ -31,6 +32,8 @@ export class WebViewComponent {
     // const pathUri = pathToHtml.with({ scheme: 'vscode-resource' });
     // panel.webview.html = fs.readFileSync(pathUri.fsPath, 'utf8');
     const priorities = workspace.getConfiguration().get('code-review.priorities') as string[];
+
+    data.comment = unescapeEndOfLineFromCsv(data.comment);
 
     const formData = { ...data };
     this.panel.webview.postMessage({ comment: formData });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

The presence of an end-of-line character in the comment part was breaking the CSV storage, leading to a loss of the comment when reloaded.

## What is the new behavior?

End-of-line characters are espaced as \\n before being saved.  
They are unescaped on load to properly restore the comment.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information