### PR TITLE
End-of-line rendering in HTML export and Tree-view

### DIFF
--- a/src/export-factory.ts
+++ b/src/export-factory.ts
@@ -13,6 +13,8 @@ import {
   sortCsvEntryForLines,
   sortLineSelections,
   rangeFromStringDefinition,
+  unescapeEndOfLineFromCsv,
+  escapeEndOfLineForCsv,
 } from './utils/workspace-util';
 import { CsvEntry, ReviewFileExportSection, GroupBy, ExportFormat, ExportMap, Group } from './interfaces';
 import { CommentListEntry } from './comment-list-entry';
@@ -71,6 +73,8 @@ export class ExportFactory {
           fs.writeFileSync(outputFile, `title,description${EOL}`);
         },
         handleData: (outputFile: string, row: CsvEntry): CsvEntry => {
+          row.comment = escapeEndOfLineForCsv(row.comment);
+
           this.includeCodeSelection ? (row.code = this.getCodeForFile(row.filename, row.lines)) : delete row.code;
           // cut the description (100 chars max) along with '...' at the end
           const descShort = row.comment.length > 100 ? `${row.comment.substring(0, 100)}...` : row.comment;
@@ -102,6 +106,8 @@ export class ExportFactory {
           fs.writeFileSync(outputFile, `title,description,labels,state,assignee${EOL}`);
         },
         handleData: (outputFile: string, row: CsvEntry): CsvEntry => {
+          row.comment = escapeEndOfLineForCsv(row.comment);
+
           this.includeCodeSelection ? (row.code = this.getCodeForFile(row.filename, row.lines)) : delete row.code;
           // cut the description (100 chars max) along with '...' at the end
           const descShort = row.comment.length > 100 ? `${row.comment.substring(0, 100)}...` : row.comment;
@@ -139,6 +145,8 @@ export class ExportFactory {
           );
         },
         handleData: (outputFile: string, row: CsvEntry): CsvEntry => {
+          row.comment = escapeEndOfLineForCsv(row.comment);
+
           this.includeCodeSelection ? (row.code = this.getCodeForFile(row.filename, row.lines)) : delete row.code;
           // cut the description (100 chars max) along with '...' at the end
           const descShort = row.comment.length > 100 ? `${row.comment.substring(0, 100)}...` : row.comment;
@@ -224,6 +232,8 @@ export class ExportFactory {
     parseFile(this.inputFile, { delimiter: ',', ignoreEmpty: true, headers: true })
       .on('error', this.handleError)
       .on('data', (row: CsvEntry) => {
+        row.comment = unescapeEndOfLineFromCsv(row.comment);
+
         if (exporter?.storeOutside) {
           const tmp = exporter.handleData(outputFile, row);
           data.push(tmp);

--- a/src/export-factory.ts
+++ b/src/export-factory.ts
@@ -250,6 +250,8 @@ export class ExportFactory {
    */
   getComments(commentGroupedInFile: CommentListEntry): Thenable<CommentListEntry[]> {
     const result = commentGroupedInFile.data.lines.map((entry: CsvEntry) => {
+      entry.comment = unescapeEndOfLineFromCsv(entry.comment);
+
       const prio = Number(entry.priority);
       const item = new CommentListEntry(
         entry.title,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

The escaping of end-of-line characters in CSV storage led to some rendering issues in HTML export and in the Tree-view (("\n" sequences were appearing in both cases).

Issue Number: N/A

## What is the new behavior?

- HTML export now show each comment line on a separate line..
- In the Tree-view, the first line of the comment is rendered. The full comment is displayed properly formatted in the tooltip.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information