### PR TITLE
Pick correct editor for good text selection 

### DIFF
--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { EOL } from 'os';
-import { window, workspace, Range, Position } from 'vscode';
+import { window, workspace, Range, Position, TextEditor } from 'vscode';
 const gitCommitId = require('git-commit-id');
 
 import { CsvEntry } from './interfaces';
@@ -29,12 +29,13 @@ export class ReviewCommentService {
   /**
    * Append a new comment
    * @param comment the comment message
+   * @param TextEditor editor The working text editor
    */
-  async addComment(comment: CsvEntry) {
+  async addComment(comment: CsvEntry, editor: TextEditor | null = null) {
     const newEntry: CsvEntry = { ...comment };
     this.checkFileExists();
 
-    const editorRef = window.activeTextEditor ?? window.visibleTextEditors[0];
+    const editorRef = editor ?? window.activeTextEditor ?? window.visibleTextEditors[0];
 
     if (!editorRef?.selection) {
       window.showErrorMessage(`Error referencing file/lines, Please select again.`);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

When adding a note on a  document with multiple editors (for example, in the diff view of the source control), the left-side editor is always picked, even if the text selected is on the right-one.

## What is the new behavior?

The correct editor is stored in the context of the note edition to be reused at validation time, when text selection is retrieved.
The correct selection is now saved.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information