### PR TITLE
feat(productivity): focus to description edit box, keyboard shortcuts

### DIFF
--- a/src/webview.html
+++ b/src/webview.html
@@ -170,7 +170,6 @@
         id="add"
         role="button"
         onclick="addNote()"
-        ,
         title="Save comment (Ctrl+Return)"
       >
         Add Note
@@ -181,7 +180,6 @@
         tabindex="0"
         role="button"
         onclick="cancel()"
-        ,
         title="Abort comment changes (Ctrl+Esc)"
       >
         Cancel

--- a/src/webview.html
+++ b/src/webview.html
@@ -164,11 +164,26 @@
           </div>
         </div>
       </div>
-      <button class="action-btn primary" tabindex="0" id="add" role="button" onclick="addNote()">
+      <button
+        class="action-btn primary"
+        tabindex="0"
+        id="add"
+        role="button"
+        onclick="addNote()"
+        ,
+        title="Save comment (Ctrl+Return)"
+      >
         Add Note
       </button>
 
-      <button class="action-btn secondary" tabindex="0" role="button" onclick="cancel()">
+      <button
+        class="action-btn secondary"
+        tabindex="0"
+        role="button"
+        onclick="cancel()"
+        ,
+        title="Abort comment changes (Ctrl+Esc)"
+      >
         Cancel
       </button>
     </form>
@@ -200,6 +215,36 @@
         document.getElementById('add').disabled = true;
       }
     });
+
+    const KEYCODE_ENTER = 13;
+    const KEYCODE_ESC = 27;
+
+    // Intercept keystrokes
+    document.addEventListener(
+      'keydown',
+      (event) => {
+        if (event.ctrlKey && !event.shiftKey && !event.altKey) {
+          switch (event.keyCode) {
+            case KEYCODE_ENTER:
+              // Ctrl+Return: comment validation
+              if (!document.getElementById('add').disabled) {
+                event.stopPropagation();
+                addNote();
+              }
+              break;
+
+            case KEYCODE_ESC:
+              // Ctrl+Esc: comment abort
+              cancel();
+              break;
+          }
+        }
+      },
+      false,
+    );
+
+    // Give focus to the comment to allow immediate typing.
+    document.getElementById('comment').focus();
 
     function addNote() {
       const title = document.getElementById('title').value;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Editing a comment involves manipulation of the mouse to give focus to the "description" edit box, then to save/cancel the comment.

Issue Number: #69

## What is the new behavior?

- Give focus to the comment edit zone so you can start typing immediately after the the note appears.
- Add some keyboard shortcut such as:
    - <kbd>Ctrl</kbd> + <kbd>Return</kbd> to validate the note.
    - <kbd>Ctrl</kbd> + <kbd>Esc</kbd> to cancel the note.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information