### PR TITLE
Fix comment deletion issues

### DIFF
--- a/src/webview.ts
+++ b/src/webview.ts
@@ -49,6 +49,7 @@ export class WebViewComponent {
 
   deleteComment(commentService: ReviewCommentService, entry: CommentListEntry) {
     commentService.deleteComment(entry);
+    this.panel?.dispose();
   }
 
   editComment(commentService: ReviewCommentService, selections: Range[], data: CsvEntry) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

When deleting a comment:

- The pane (webview) containg the comments details remains opened.
- The deletion fails for comments containing double-quotes or carriage returns.

The deletion of all comments leads to a "corrupted" storage, i.e. the file (containg just the header line) doesn't terminate with an EOL.

## What is the new behavior?

When deleting a comment:

- The pane (webview) is closed.
- It is now possible to delete comments containing double-quotes or carriage returns.
- The storage remains consistent even after deleting all comments.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information