### PR TITLE
Ability to update the selection of an existing note

### DIFF
--- a/src/utils/editor-utils.ts
+++ b/src/utils/editor-utils.ts
@@ -1,0 +1,68 @@
+import { Position, Range, Selection, TextEditor, TextEditorDecorationType, window } from 'vscode';
+
+/**
+ * Reset the selection in an editor
+ *
+ * @param editor The editor to work on
+ */
+export const clearSelection = (editor: TextEditor): void => {
+  if (hasSelection(editor)) {
+    editor.selections = [new Selection(new Position(0, 0), new Position(0, 0))];
+  }
+};
+
+/**
+ * Check if there is some selected text in an editor
+ *
+ * @param editor The editor to check
+ * @return bool
+ */
+export const hasSelection = (editor: TextEditor | null): boolean => {
+  const isSelectionNone =
+    editor?.selections.reduce((acc: boolean, cur) => {
+      return acc && cur.start.isEqual(cur.end);
+    }, true) ?? true;
+
+  return !isSelectionNone;
+};
+
+/**
+ * Get the selected lines string representation in an editor
+ *
+ * @param editor The editor to work on
+ * @return string The string represention of the selected lines
+ */
+export const getSelectionStringDefinition = (editor: TextEditor): string => {
+  return editor.selections.reduce((acc, cur) => {
+    const tmp = acc ? `${acc}|` : '';
+    return `${tmp}${cur.start.line + 1}:${cur.start.character}-${cur.end.line + 1}:${cur.end.character}`;
+  }, '');
+};
+
+/**
+ * Get the selected lines in an editor
+ *
+ * @param editor The editor to work on
+ * @return Range[]
+ */
+export const getSelectionRanges = (editor: TextEditor): Range[] => {
+  return editor.selections.map((el) => {
+    return new Range(new Position(el.start.line, el.start.character), new Position(el.end.line, el.end.character));
+  });
+};
+
+/**
+ * Highlight a selection in an editor
+ *
+ * @param selections The selection to highlight
+ * @param editor The editor to work on
+ * @return TextEditorDecorationType
+ */
+export const colorizeSelection = (selections: Range[], editor: TextEditor): TextEditorDecorationType => {
+  const decoration = window.createTextEditorDecorationType({
+    backgroundColor: 'rgba(200, 200, 50, 0.15)',
+  });
+  editor.setDecorations(decoration, selections);
+
+  return decoration;
+};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

When updating a note, it is not possible to modify the selected text.

Issue:  #72

## What is the new behavior?

When validating the update of a comment, the selection will also be updated if some text is selected. It will remain the same otherwise.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Not really a breaking change, but this feature requires to clear the current selection of the editor containing the comment when this one is selected. This is needed to detect a new selection.

## Other information