### PR TITLE
Avoid duplicate panels when adding a comment

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -166,7 +166,6 @@ export function activate(context: ExtensionContext) {
       workspace.openTextDocument(filePath).then(
         (doc) => {
           window.showTextDocument(doc, ViewColumn.One).then((textEditor) => {
-            webview.panel?.dispose(); // dispose previous ones
             if (csvRef) {
               const rangesStringArray = csvRef.lines.split('|');
               const ranges: Range[] = rangesStringArray.map((range) => rangeFromStringDefinition(range));

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -10,9 +10,25 @@ import { clearSelection, colorizeSelection, getSelectionRanges } from './utils/e
 
 export class WebViewComponent {
   private categories: string[] = [];
-  public panel: WebviewPanel | null = null;
+  /** Panel used to add/edit a comment */
+  private panel: WebviewPanel | null = null;
   /** Reference to the working editor during note edition */
   private editor: TextEditor | null = null;
+
+  /**
+   * Show the comment edition panel
+   *
+   * @param title The title of the panel
+   * @param fileName The file referenced by the comment
+   * @return WebviewPanel The panel object
+   */
+  private showPanel(title: string, fileName: string): WebviewPanel {
+    this.panel?.dispose(); // Dispose existing panel to avoid duplicates
+    this.panel = this.createWebView(title);
+    this.panel.webview.html = this.getWebviewContent(fileName);
+
+    return this.panel;
+  }
 
   constructor(public context: ExtensionContext) {
     this.categories = workspace.getConfiguration().get('code-review.categories') as string[];
@@ -52,8 +68,7 @@ export class WebViewComponent {
     const decoration = colorizeSelection(selections, editor);
 
     // initialize new web tab
-    this.panel = this.createWebView('Edit code review comment');
-    this.panel.webview.html = this.getWebviewContent(editor.document.fileName);
+    const panel = this.showPanel('Edit code review comment', editor.document.fileName);
     // const pathToHtml = Uri.file(path.join(this.context.extensionPath, 'src', 'webview.html'));
     // const pathUri = pathToHtml.with({ scheme: 'vscode-resource' });
     // panel.webview.html = fs.readFileSync(pathUri.fsPath, 'utf8');
@@ -62,10 +77,10 @@ export class WebViewComponent {
     data.comment = unescapeEndOfLineFromCsv(data.comment);
 
     const formData = { ...data };
-    this.panel.webview.postMessage({ comment: formData });
+    panel.webview.postMessage({ comment: formData });
 
     // Handle messages from the webview
-    this.panel.webview.onDidReceiveMessage(
+    panel.webview.onDidReceiveMessage(
       (message) => {
         switch (message.command) {
           case 'submit':
@@ -79,10 +94,10 @@ export class WebViewComponent {
               priority: formData.priority || 0,
             };
             commentService.updateComment(newEntry, this.getWorkingEditor());
-            this.panel?.dispose();
+            panel.dispose();
             return;
           case 'cancel':
-            this.panel?.dispose();
+            panel.dispose();
             return;
         }
       },
@@ -90,7 +105,7 @@ export class WebViewComponent {
       this.context.subscriptions,
     );
 
-    this.panel.onDidDispose(() => {
+    panel.onDidDispose(() => {
       // reset highlight selected lines
       decoration.dispose();
       this.disposeWorkingEditor();
@@ -102,14 +117,13 @@ export class WebViewComponent {
     const editor = this.getWorkingEditor();
     const decoration = colorizeSelection(getSelectionRanges(editor), editor);
 
-    this.panel = this.createWebView('Add code review comment');
-    this.panel.webview.html = this.getWebviewContent(editor.document.fileName);
+    const panel = this.showPanel('Add code review comment', editor.document.fileName);
     // const pathToHtml = Uri.file(path.join(this.context.extensionPath, 'src', 'webview.html'));
     // const pathUri = pathToHtml.with({ scheme: 'vscode-resource' });
     // panel.webview.html = fs.readFileSync(pathUri.fsPath, 'utf8');
 
     // Handle messages from the webview
-    this.panel.webview.onDidReceiveMessage(
+    panel.webview.onDidReceiveMessage(
       (message) => {
         switch (message.command) {
           case 'submit':
@@ -122,13 +136,13 @@ export class WebViewComponent {
             break;
         }
 
-        this.panel?.dispose();
+        panel.dispose();
       },
       undefined,
       this.context.subscriptions,
     );
 
-    this.panel.onDidDispose(() => {
+    panel.onDidDispose(() => {
       // reset highlight selected lines
       decoration.dispose();
       this.disposeWorkingEditor();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Steps to reproduce:

1. Display a comment by selecting one in the tree-view.
2. The panel with the comment to edit is displayed.
3. Select some text in the text-editor, and "Add a note".
4. This will open a new panel.
5. When the new comment is validted, the previous panel remains visible, and inactive.

## What is the new behavior?

When adding a comment, the current panel is closed.
Note it is not asked to update/save the content of the closed panel. This could be a future improvement (support of dirty mode).

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information

This fix was the opportunity to reserve exclusive manipulation of the `panel`object to the `WebViewComponent`component.