### PR TITLE
fix: prevent workspace refreshes for subpath workspaces

### DIFF
--- a/src/test/suite/workspace-util.test.ts
+++ b/src/test/suite/workspace-util.test.ts
@@ -26,6 +26,7 @@ import {
   rangesFromStringDefinition,
   splitStringDefinition,
   getBackupFilename,
+  isProperSubpathOf,
 } from '../../utils/workspace-util';
 import { createCommentFromObject, CsvEntry, CsvStructure } from '../../model';
 import { cleanCsvStorage, getCsvFileHeader } from '../../utils/storage-utils';
@@ -50,6 +51,21 @@ suite('Workspace Utils', () => {
     test('should remove a trailing slash from a string', () => {
       assert.strictEqual(removeLeadingAndTrailingSlash('/foo/bar/'), 'foo/bar');
       assert.strictEqual(removeLeadingAndTrailingSlash('\\foo/bar\\'), 'foo/bar');
+    });
+  });
+
+  suite('isProperSubpathOf', () => {
+    test('should be true for proper subpaths', () => {
+      assert.strictEqual(isProperSubpathOf('/home/user/workspace/file', '/home/user/workspace'), true);
+      assert.strictEqual(isProperSubpathOf('/home/user/workspace/file', '/'), true);
+    });
+
+    test('should be false for improper subpaths', () => {
+      assert.strictEqual(isProperSubpathOf('/home/user/workspace/file', '/home/user/workspace/file'), false);
+    });
+
+    test('should be false for non-subpaths', () => {
+      assert.strictEqual(isProperSubpathOf('/home/user/workspace', '/home/user/workspace/file'), false);
     });
   });
 

--- a/src/utils/workspace-util.ts
+++ b/src/utils/workspace-util.ts
@@ -23,6 +23,17 @@ export const removeLeadingSlash = (s: string): string => s.replace(/^\/|^\\/, ''
 export const removeLeadingAndTrailingSlash = (s: string): string => removeLeadingSlash(removeTrailingSlash(s));
 
 /**
+ * Check is `dir` is a proper subpath of `base`.
+ * @param dir Directory to check if being a subpath of `base`.
+ * @param base Base directory.
+ * @returns Whether `dir` is a proper subpath of `base`.
+ */
+export const isProperSubpathOf = (dir: string, base: string): boolean => {
+  const relative = path.relative(base, dir);
+  return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+};
+
+/**
  * Get the path name of the workspace
  * workspace root, assumed to be the first item in the array
  * @param folders the workspace folder object from vscode (via: `vscode.workspace.workspaceFolders`)


### PR DESCRIPTION
... which in particular happens when commenting code in a diff view.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Situation:

* Open a diff for a file in a subfolder of the project's root
* Comment on the diff of the file
* Observe that in the `code-review.csv` will not be the workspace-relative path to the file, but just the file's name

Reason: Opening a diff view changes the active editor, cause the `onDidChangeActiveTextEditor` to fire which, in turn, then sets the workspace to the file's directory --- which differs from the previous workspace.

Issue Number: N/A

## What is the new behavior?

If `onDidChangeActiveTextEditor`, the workspace will only be refreshed if it is neither equal nor a proper subpath of the current workspace.

Caveat: I am not a VSCode Extension expert. :) There might be actual use cases where this change in behaviour does not produce the desired outcome. So I am very happy for comments on my approach. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information