### PR TITLE
fix (missing quoting/escaping of double quotes upon CSV export) - Issue #158

### DIFF
--- a/src/export-factory.ts
+++ b/src/export-factory.ts
@@ -26,6 +26,7 @@ import {
   sortLineSelections,
   rangeFromStringDefinition,
   escapeEndOfLineForCsv,
+  escapeDoubleQuotesForCsv,
   standardizeFilename,
   splitStringDefinition,
 } from './utils/workspace-util';
@@ -110,6 +111,22 @@ export class ExportFactory {
       (this.currentFilename === null || entry.filename === this.currentFilename) &&
       (!this.filterByPriority || entry.priority != 1) // prio value 1 = green traffic light
     );
+  }
+
+  /**
+   * Properly escape newlines and quotes in CVS entries
+   * @param entry The CVS entry to escape
+   */
+  private escapeCVSEntry(entry: CsvEntry): CsvEntry {
+    entry.comment = escapeEndOfLineForCsv(escapeDoubleQuotesForCsv(entry.comment));
+    entry.title = entry.title ? escapeDoubleQuotesForCsv(entry.title) : entry.title;
+    entry.filename = escapeDoubleQuotesForCsv(entry.filename);
+    entry.lines = escapeDoubleQuotesForCsv(entry.lines);
+    entry.sha = escapeDoubleQuotesForCsv(entry.sha);
+    entry.additional = entry.additional ? escapeDoubleQuotesForCsv(entry.additional) : entry.additional;
+    entry.category = escapeDoubleQuotesForCsv(entry.category);
+
+    return entry;
   }
 
   private exportHandlerMap = new Map<ExportFormat, ExportMap>([
@@ -215,7 +232,7 @@ export class ExportFactory {
           fs.writeFileSync(outputFile, `title,description${EOL}`);
         },
         handleData: (outputFile: string, row: CsvEntry): CsvEntry => {
-          row.comment = escapeEndOfLineForCsv(row.comment);
+          row = this.escapeCVSEntry(row);
 
           this.includeCodeSelection ? (row.code = this.getCodeForFile(row.filename, row.lines)) : delete row.code;
           // cut the description (100 chars max) along with '...' at the end
@@ -248,7 +265,7 @@ export class ExportFactory {
           fs.writeFileSync(outputFile, `title,description,labels,state,assignee${EOL}`);
         },
         handleData: (outputFile: string, row: CsvEntry): CsvEntry => {
-          row.comment = escapeEndOfLineForCsv(row.comment);
+          row = this.escapeCVSEntry(row);
 
           this.includeCodeSelection ? (row.code = this.getCodeForFile(row.filename, row.lines)) : delete row.code;
           // cut the description (100 chars max) along with '...' at the end
@@ -287,7 +304,7 @@ export class ExportFactory {
           );
         },
         handleData: (outputFile: string, row: CsvEntry): CsvEntry => {
-          row.comment = escapeEndOfLineForCsv(row.comment);
+          row = this.escapeCVSEntry(row);
 
           this.includeCodeSelection ? (row.code = this.getCodeForFile(row.filename, row.lines)) : delete row.code;
           // cut the description (100 chars max) along with '...' at the end


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Double quote characters ('"') are not properly escaped/quote upon export as CSV file for github, gitlab, or JIRA import.

Subsequent import fails due to malformed CSV file.

Issue Number: #158 

## What is the new behavior?

Double quote characters ('"') are not properly escaped/quote upon export as CSV file for github, gitlab, or JIRA import.

Subsequent import succeeds due to well-formed CSV file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information